### PR TITLE
Include build script to move resources to target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rocket"
 version = "0.1.0"
 authors = ["Adolfo Ochagavía <aochagavia92@gmail.com>"]
+build = "build.rs"
 
 [dependencies]
 itertools = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,34 @@
+use std::env;
+use std::fs::{copy, create_dir_all, read_dir};
+use std::path::{Path, PathBuf};
+use std::io;
+
+fn main() {
+    let res_dir_source = Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap()).join("resources/");
+    let res_dir_target = Path::new(&env::var("OUT_DIR").unwrap()).join("../../../resources/");
+
+    //copies all resource files to "target/NAME/resources". Prints out any errors if failed.
+    if let Err(io_error) = add_resources(&res_dir_source, &res_dir_target) {
+        println!("OS Error: {}", io_error);
+    }
+}
+
+///Recursively copy all files in dir given by source_path to dir given by target path
+///WARNING! Overwrites files with same name
+fn add_resources(source_path: &PathBuf, target_path: &PathBuf) -> io::Result<()> {
+    match read_dir(source_path) {
+        Ok(entry_iter) => {
+            try!(create_dir_all(target_path));
+            for entry in entry_iter {
+                let entry = try!(entry);
+                let source_path = entry.path();
+                let target_path = target_path.join(entry.file_name());
+                try!(add_resources(&source_path, &target_path));
+            }
+        }
+        Err(_) => {
+            try!(copy(&source_path, &target_path));
+        }
+    }
+    Ok(())
+}

--- a/src/game.rs
+++ b/src/game.rs
@@ -1,7 +1,7 @@
 //! This module contains the game logic
 
 use std::f64;
-use std::path::Path;
+use std::env::current_exe;
 
 use graphics::{self, Transformed};
 use itertools;
@@ -60,13 +60,14 @@ impl Game {
     /// Returns a new `Game` containing a `World` of the given `Size`
     pub fn new(size: Size) -> Game {
         let mut rng = rand::thread_rng();
+        let exe_directory = current_exe().unwrap().parent().unwrap().to_owned();
         Game {
             world: World::new(&mut rng, size),
             score: 0,
             actions: Actions::default(),
             timers: Timers::default(),
             rng: rng,
-            resources: Resources { font: GlyphCache::new(&Path::new("resources/FiraMono-Bold.ttf")).unwrap() }
+            resources: Resources { font: GlyphCache::new(&exe_directory.join("resources/FiraMono-Bold.ttf")).unwrap() }
         }
     }
 


### PR DESCRIPTION
`src/game.rs` now looks in new location for resources. `rocket` should
no longer panic if called from wrong place.

Closes #5